### PR TITLE
Br nav search

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,14 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  before_action :set_cart, :login_status
+  before_action :set_cart, :login_status, :get_items
 
   helper_method :current_user
+
+  def get_items
+    @search = Item.search(params[:q])
+    @q = Item.ransack(params[:q])
+    @items = @q.result.includes(:category)
+  end
 
   def current_user
     @current_user ||= User.find(session[:user]) if session[:user]

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,6 @@
 class ItemsController < ApplicationController
 
   def index
-    @search = Item.search(params[:q])
-    @q = Item.ransack(params[:q])
-    @items = @q.result.includes(:category)
   end
 
   def show

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,13 +1,9 @@
 </br></br></br>
 <%= search_form_for @search do |f| %>
-  <span class="field">
-    <%= f.label :title_cont, "Item Title Contains:"%>
-    <%= f.text_field :title_cont %>
-  </span>
     <%= f.label :category_name_cont, "Category Name Contains:" %>
     <%= f.search_field :category_name_cont %>
   <span class="actions">
-    <%= f.submit "Search" %>
+    <%= f.submit "Category Search" %>
   </span>
 <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,14 @@
 				<span class="icon-bar"></span>
 			</button>
 			<a href="/"><%= image_tag "gryffindor_crest", class: "brand" %></a>
-		</div>
+    </div>
+		<div class="nav navbar-nav navbar-center" id="navbar">
+        <%= search_form_for @search do |f| %>
+            <%= f.label :title_cont, "Item Title Contains:"%>
+            <%= f.text_field :title_cont %>
+            <%= f.submit "Item Search" %>
+        <% end %>
+    </div>
 		<div class="collapse navbar-collapse" id="navbar">
 			<ul class="nav navbar-nav navbar-right">
         <li><%= session[:message] %><span class="sr-only">(current)</span></li>

--- a/spec/features/items/items_can_be_searched_by_category_spec.rb
+++ b/spec/features/items/items_can_be_searched_by_category_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'items can be searched by strings included in category name' do
 
       fill_in "q[category_name_cont]", with: "hiking"
 
-      click_on "Search"
+      click_on "Category Search"
 
       expect(page).to have_content("a1")
       expect(page).to have_content("a2")
@@ -39,7 +39,7 @@ RSpec.feature 'items can be searched by strings included in category name' do
 
       fill_in "q[category_name_cont]", with: "fishing"
 
-      click_on "Search"
+      click_on "Category Search"
 
       expect(page).to have_content("b1")
       expect(page).to have_content("b2")
@@ -54,7 +54,7 @@ RSpec.feature 'items can be searched by strings included in category name' do
 
       fill_in "q[category_name_cont]", with: "climbing"
 
-      click_on "Search"
+      click_on "Category Search"
 
       expect(page).to have_content("c1")
       expect(page).to have_content("c2")
@@ -69,7 +69,7 @@ RSpec.feature 'items can be searched by strings included in category name' do
 
       fill_in "q[category_name_cont]", with: "x"
 
-      click_on "Search"
+      click_on "Category Search"
 
       expect(page).to_not have_content("a1")
       expect(page).to_not have_content("b2")

--- a/spec/features/items/items_search_by_title_spec.rb
+++ b/spec/features/items/items_search_by_title_spec.rb
@@ -39,31 +39,3 @@ RSpec.feature 'items can be searched by strings included in item title' do
   end
 
 end
-
-require 'rails_helper'
-
-RSpec.feature 'visitor can search for items from navbar' do
-  before(:each) do
-    a1 = create(:item, title: "a1")
-    a2 = create(:item, title: "a2")
-    b1 = create(:item, title: "b1")
-    b2 = create(:item, title: "b2")
-  end
-
-  describe 'visitor can search items from:' do
-    scenario 'landing page' do
-      visit root_path
-
-      within('ul') do
-        fill_in 'q[title_cont]', with: "a"
-        click_on 'Search'
-      end
-
-      expect(current_path).to eq(items_path)
-      expect(page).to have_content("a1")
-      expect(page).to have_content('a2')
-      expect(page).to_not have_content('b1')
-      expect(page).to_not have_content('b2')
-    end
-  end
-end

--- a/spec/features/items/items_search_by_title_spec.rb
+++ b/spec/features/items/items_search_by_title_spec.rb
@@ -39,3 +39,31 @@ RSpec.feature 'items can be searched by strings included in item title' do
   end
 
 end
+
+require 'rails_helper'
+
+RSpec.feature 'visitor can search for items from navbar' do
+  before(:each) do
+    a1 = create(:item, title: "a1")
+    a2 = create(:item, title: "a2")
+    b1 = create(:item, title: "b1")
+    b2 = create(:item, title: "b2")
+  end
+
+  describe 'visitor can search items from:' do
+    scenario 'landing page' do
+      visit root_path
+
+      within('ul') do
+        fill_in 'q[title_cont]', with: "a"
+        click_on 'Search'
+      end
+
+      expect(current_path).to eq(items_path)
+      expect(page).to have_content("a1")
+      expect(page).to have_content('a2')
+      expect(page).to_not have_content('b1')
+      expect(page).to_not have_content('b2')
+    end
+  end
+end

--- a/spec/features/items/items_search_by_title_spec.rb
+++ b/spec/features/items/items_search_by_title_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'items can be searched by strings included in item title' do
     expect(page).to have_content("a1")
     expect(page).to have_content("b1")
 
-    click_on "Search"
+    click_on "Item Search"
 
     expect(page).to have_content("a1")
     expect(page).to have_content("a2")
@@ -30,7 +30,7 @@ RSpec.feature 'items can be searched by strings included in item title' do
     expect(page).to have_content("a1")
     expect(page).to have_content("b1")
 
-    click_on "Search"
+    click_on "Item Search"
 
     expect(page).to have_content("b1")
     expect(page).to have_content("b2")

--- a/spec/features/items/vistior_can_search_items_from_navbar_spec.rb
+++ b/spec/features/items/vistior_can_search_items_from_navbar_spec.rb
@@ -12,10 +12,34 @@ RSpec.feature 'visitor can search for items from navbar' do
     scenario 'landing page' do
       visit root_path
 
-      within('ul') do
-        fill_in 'q[title_cont]', with: "a"
-        click_on 'Search'
-      end
+      fill_in 'q[title_cont]', with: "a"
+      click_on 'Search'
+
+      expect(current_path).to eq(items_path)
+      expect(page).to have_content("a1")
+      expect(page).to have_content('a2')
+      expect(page).to_not have_content('b1')
+      expect(page).to_not have_content('b2')
+    end
+
+    scenario 'cart' do
+      visit cart_path
+
+      fill_in 'q[title_cont]', with: "b"
+      click_on 'Search'
+
+      expect(current_path).to eq(items_path)
+      expect(page).to have_content("b1")
+      expect(page).to have_content('b2')
+      expect(page).to_not have_content('a1')
+      expect(page).to_not have_content('a2')
+    end
+
+    scenario 'dashboard' do
+      visit dashboard_path
+
+      fill_in 'q[title_cont]', with: "a"
+      click_on 'Search'
 
       expect(current_path).to eq(items_path)
       expect(page).to have_content("a1")

--- a/spec/features/items/vistior_can_search_items_from_navbar_spec.rb
+++ b/spec/features/items/vistior_can_search_items_from_navbar_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.feature 'visitor can search for items from navbar' do
+  before(:each) do
+    a1 = create(:item, title: "a1")
+    a2 = create(:item, title: "a2")
+    b1 = create(:item, title: "b1")
+    b2 = create(:item, title: "b2")
+  end
+
+  describe 'visitor can search items from:' do
+    scenario 'landing page' do
+      visit root_path
+
+      within('ul') do
+        fill_in 'q[title_cont]', with: "a"
+        click_on 'Search'
+      end
+
+      expect(current_path).to eq(items_path)
+      expect(page).to have_content("a1")
+      expect(page).to have_content('a2')
+      expect(page).to_not have_content('b1')
+      expect(page).to_not have_content('b2')
+    end
+  end
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -8,11 +8,26 @@ RSpec.configure do |config|
       DatabaseCleaner.clean
     end
   end
-  
+
   Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec
     with.library :rails
+    end
+  end
+
+end
+
+RSpec.configure do |config|
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
     end
   end
 


### PR DESCRIPTION
@Sh1pley @DavidKnott @ethanbennett 

This moves the item search to the navbar, it is searchable from all pages and links to the items index, where you can then search by category.

This also fixes the database cleaner, I had to rake db:reset one time to many

All tests passing